### PR TITLE
Ensure input type is bytes under Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,7 @@ class PartitionRouter(BaseRouter):
         assert_gapless_hosts(self.cluster.hosts)
 
     def get_host_for_key(self, key):
-        if isinstance(key, text_type):
-            k = key.encode('utf-8')
-        else:
-            k = bytes_type(key)
+        k = six.ensure_binary(key)
         # Make sure return value same as in Python3
         # return (crc32(k) & 0xffffffff) % len(self.cluster.hosts)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ But may turn to use Python 3's native `crc32` function in the future.
 - [ ] option to choose `crc32`'s method
 - [ ] fix macOS travis test
 - [ ] fix pypy travis test
+- [ ] validate functions
 
 # rb's original README
 

--- a/rb/__init__.py
+++ b/rb/__init__.py
@@ -14,7 +14,7 @@ from rb.router import BaseRouter, ConsistentHashingRouter, PartitionRouter, \
 from rb.promise import Promise
 
 
-__version__ = '1.8'
+__version__ = '1.8.1'
 
 __all__ = [
     # cluster

--- a/rb/ketama.py
+++ b/rb/ketama.py
@@ -1,12 +1,13 @@
 import hashlib
 import math
+import six
 
 from bisect import bisect
 
 
 def md5_bytes(key):
     # Py2: map(ord, hashlib.md5(key).digest())
-    return list(hashlib.md5(key.encode('utf-8')).digest())
+    return list(hashlib.md5(six.ensure_binary(key)).digest())
 
 
 class Ketama(object):

--- a/rb/router.py
+++ b/rb/router.py
@@ -1,9 +1,11 @@
-from weakref import ref as weakref
 from binascii import crc32
+from weakref import ref as weakref
 
-from rb.ketama import Ketama
-from rb.utils import text_type, bytes_type
+import six
+
 from rb._rediscommands import COMMANDS
+from rb.ketama import Ketama
+from rb.utils import bytes_type, text_type
 
 
 class UnroutableCommand(Exception):
@@ -136,10 +138,7 @@ class PartitionRouter(BaseRouter):
         assert_gapless_hosts(self.cluster.hosts)
 
     def get_host_for_key(self, key):
-        if isinstance(key, text_type):
-            k = key.encode('utf-8')
-        else:
-            k = bytes_type(key)
+        k = six.ensure_binary(key)
         # Make sure return value same as in Python3
         # return (crc32(k) & 0xffffffff) % len(self.cluster.hosts)
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     keywords='Redis rb python3',
     install_requires=[
         'redis>=2.6',
+        'six>=1.12.0'
     ],
     classifiers=[
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
Previous type checking may fail, and cause error.

```python
        if isinstance(key, text_type):
            k = key.encode('utf-8')
        else:
            k = bytes_type(key)
```

So turn to use `six.ensure_binary`.

Prerelease: https://test.pypi.org/manage/project/rb3/release/1.8.1/

Install by:`pip install -i https://test.pypi.org/simple/ rb3==1.8.1`